### PR TITLE
added quantityAvailable to variant data type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/types",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -80,6 +80,7 @@ export type ProductVariant = {
   metafields?: Maybe<Array<Metafield>>;
   weight?: Maybe<Scalars['Float']>;
   weightUnit?: Maybe<Scalars['String']>;
+  quantityAvailable?: Maybe<Scalars['Int']>;
 };
 
 export type ProductPriceRule = {

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -75,6 +75,7 @@ export default `#graphql
     metafields: [Metafield!]
     weight: Float
     weightUnit: String
+    quantityAvailable: Int
   }
 
   type ProductPriceRule {


### PR DESCRIPTION
### WHY are these changes introduced?

For [[NC-1732](https://nacelle.atlassian.net/browse/NC-1732)]

### WHAT is this pull request doing?

Allows the user to optionally retrieve `quantityAvailable` variant attribute if it has been indexed.