### PR TITLE
Add readToken to space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nacelle/types",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -279,6 +279,18 @@ export type NacelleSpace = {
   featureFlags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
+export type NacelleShopSpace = {
+  id: Scalars['ID'];
+  type?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  domain?: Maybe<Scalars['String']>;
+  pimSyncSourceDomain: Scalars['String'];
+  cmsSyncSourceDomain: Scalars['String'];
+  linklists?: Maybe<Array<SpaceLinkList>>;
+  affinityLinklists?: Maybe<Array<SpaceAffinityLinkList>>;
+  metafields?: Maybe<Array<Metafield>>;
+};
+
 /** Configuration settings for retrieving content from a CMS */
 export type ContentDataConfig = {
   dataSource?: Maybe<Scalars['String']>;

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -279,6 +279,17 @@ export type NacelleSpace = {
   featureFlags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
+export type NacelleShopSpace = {
+  id: Scalars['ID'];
+  name?: Maybe<Scalars['String']>;
+  domain?: Maybe<Scalars['String']>;
+  metafields?: Maybe<Array<Metafield>>;
+  linklists?: Maybe<Array<SpaceLinkList>>;
+  affinityLinklists?: Maybe<Array<SpaceAffinityLinkList>>;
+  pimSyncSourceDomain: Scalars['String'];
+  cmsSyncSourceDomain: Scalars['String'];
+};
+
 /** Configuration settings for retrieving content from a CMS */
 export type ContentDataConfig = {
   dataSource?: Maybe<Scalars['String']>;

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -264,7 +264,7 @@ export type NacelleSpace = {
   name?: Maybe<Scalars['String']>;
   domain?: Maybe<Scalars['String']>;
   token?: Maybe<Scalars['String']>;
-  readToken?: Maybe<Scalars['String']>;
+  publicToken?: Maybe<Scalars['String']>;
   pimSyncSourceDomain: Scalars['String'];
   cmsSyncSourceDomain: Scalars['String'];
   linklists?: Maybe<Array<SpaceLinkList>>;

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -264,6 +264,7 @@ export type NacelleSpace = {
   name?: Maybe<Scalars['String']>;
   domain?: Maybe<Scalars['String']>;
   token?: Maybe<Scalars['String']>;
+  readToken?: Maybe<Scalars['String']>;
   pimSyncSourceDomain: Scalars['String'];
   cmsSyncSourceDomain: Scalars['String'];
   linklists?: Maybe<Array<SpaceLinkList>>;

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -279,18 +279,6 @@ export type NacelleSpace = {
   featureFlags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type NacelleShopSpace = {
-  id: Scalars['ID'];
-  type?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  domain?: Maybe<Scalars['String']>;
-  pimSyncSourceDomain: Scalars['String'];
-  cmsSyncSourceDomain: Scalars['String'];
-  linklists?: Maybe<Array<SpaceLinkList>>;
-  affinityLinklists?: Maybe<Array<SpaceAffinityLinkList>>;
-  metafields?: Maybe<Array<Metafield>>;
-};
-
 /** Configuration settings for retrieving content from a CMS */
 export type ContentDataConfig = {
   dataSource?: Maybe<Scalars['String']>;

--- a/src/graphql.types.ts
+++ b/src/graphql.types.ts
@@ -279,17 +279,6 @@ export type NacelleSpace = {
   featureFlags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
-export type NacelleShopSpace = {
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
-  domain?: Maybe<Scalars['String']>;
-  metafields?: Maybe<Array<Metafield>>;
-  linklists?: Maybe<Array<SpaceLinkList>>;
-  affinityLinklists?: Maybe<Array<SpaceAffinityLinkList>>;
-  pimSyncSourceDomain: Scalars['String'];
-  cmsSyncSourceDomain: Scalars['String'];
-};
-
 /** Configuration settings for retrieving content from a CMS */
 export type ContentDataConfig = {
   dataSource?: Maybe<Scalars['String']>;

--- a/src/space.types.ts
+++ b/src/space.types.ts
@@ -1,4 +1,8 @@
-import { Metafield, SpaceLinkList } from './graphql.types';
+import {
+  Metafield,
+  SpaceLinkList,
+  SpaceAffinityLinkList
+} from './graphql.types';
 
 /**
  * Nacelle space as it is retrieved from the database.
@@ -36,6 +40,7 @@ export interface NacelleShopSpace {
   domain: string;
   metafields: Metafield[];
   linklists: SpaceLinkList[];
+  affinityLinklists: SpaceAffinityLinkList[];
   pimSyncSourceDomain: string;
   cmsSyncSourceDomain: string;
 }

--- a/src/space.types.ts
+++ b/src/space.types.ts
@@ -15,7 +15,7 @@ export interface DatabaseSpace {
   name: string;
   domain: string;
   token: string;
-  readToken?: string;
+  publicToken?: string;
   pimSyncSourceDomain: string;
   cmsSyncSourceDomain: string;
   linklists: string;

--- a/src/space.types.ts
+++ b/src/space.types.ts
@@ -11,6 +11,7 @@ export interface DatabaseSpace {
   name: string;
   domain: string;
   token: string;
+  readToken?: string;
   pimSyncSourceDomain: string;
   cmsSyncSourceDomain: string;
   linklists: string;

--- a/src/space.types.ts
+++ b/src/space.types.ts
@@ -29,18 +29,3 @@ export interface DatabaseSpace {
   users: string;
   featureFlags: string;
 }
-
-/**
- * Abbreviated Nacelle space as it is retrieved
- * from the SDK and used in frontend applications
- */
-export interface NacelleShopSpace {
-  id: string;
-  name: string;
-  domain: string;
-  metafields: Metafield[];
-  linklists: SpaceLinkList[];
-  affinityLinklists: SpaceAffinityLinkList[];
-  pimSyncSourceDomain: string;
-  cmsSyncSourceDomain: string;
-}

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -274,6 +274,19 @@ export default `#graphql
     featureFlags: [String]
   }
 
+
+  type NacelleShopSpace {
+    id: ID!
+    type: String
+    name: String
+    domain: String
+    pimSyncSourceDomain: String!
+    cmsSyncSourceDomain: String!
+    linklists: [SpaceLinkList!]
+    affinityLinklists: [SpaceAffinityLinkList!]
+    metafields: [Metafield!]
+  }
+
   "Configuration settings for retrieving content from a CMS"
   type ContentDataConfig {
     dataSource: String

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -259,7 +259,7 @@ export default `#graphql
     name: String
     domain: String
     token: String
-    readToken?: String
+    readToken: String
     pimSyncSourceDomain: String!
     cmsSyncSourceDomain: String!
     linklists: [SpaceLinkList!]

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -259,6 +259,7 @@ export default `#graphql
     name: String
     domain: String
     token: String
+    readToken?: String
     pimSyncSourceDomain: String!
     cmsSyncSourceDomain: String!
     linklists: [SpaceLinkList!]

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -274,18 +274,6 @@ export default `#graphql
     featureFlags: [String]
   }
 
-  type NacelleShopSpace {
-    id: ID!
-    type: String
-    name: String
-    domain: String
-    pimSyncSourceDomain: String!
-    cmsSyncSourceDomain: String!
-    linklists: [SpaceLinkList!]
-    affinityLinklists: [SpaceAffinityLinkList!]
-    metafields: [Metafield!]
-  }
-
   "Configuration settings for retrieving content from a CMS"
   type ContentDataConfig {
     dataSource: String

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -259,7 +259,7 @@ export default `#graphql
     name: String
     domain: String
     token: String
-    readToken: String
+    publicToken: String
     pimSyncSourceDomain: String!
     cmsSyncSourceDomain: String!
     linklists: [SpaceLinkList!]

--- a/src/type-defs.ts
+++ b/src/type-defs.ts
@@ -274,6 +274,18 @@ export default `#graphql
     featureFlags: [String]
   }
 
+  type NacelleShopSpace {
+    id: ID!
+    type: String
+    name: String
+    domain: String
+    pimSyncSourceDomain: String!
+    cmsSyncSourceDomain: String!
+    linklists: [SpaceLinkList!]
+    affinityLinklists: [SpaceAffinityLinkList!]
+    metafields: [Metafield!]
+  }
+
   "Configuration settings for retrieving content from a CMS"
   type ContentDataConfig {
     dataSource: String


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses [[NC-1805](https://nacelle.atlassian.net/browse/NC-1805)]

In order to improve security for our merchants and prevent possible defacement issues, we need to separate the tokens we use on the backend from Hail Frequency.

To do this we will add a `readToken` to the Nacelle space object. A new version of Hail Frequency will authenticate against this `readToken` instead of the existing `token`, which will be reserved for Dilithium.

We also need to provide functionality for merchants to periodically refresh those tokens.

### WHAT is this pull request doing?

- Adds `readToken` to `NacelleSpace` type and graphql schema definitions
- Adds `NacelleShopSpace` to `graphql.types.ts`